### PR TITLE
Ignore ruff rule S603

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -91,7 +91,7 @@ select = [
     "PLE",
     "RUF",
 ]
-ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D107"]
+ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D107", "S603"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101"]


### PR DESCRIPTION
This rule effectively always requires a noqa to use subprocess